### PR TITLE
feat: 닉네임 중복 체크 api 추가

### DIFF
--- a/infra/infra-security/src/main/kotlin/com/kw/infrasecurity/config/WebSecurityConfig.kt
+++ b/infra/infra-security/src/main/kotlin/com/kw/infrasecurity/config/WebSecurityConfig.kt
@@ -63,11 +63,11 @@ class WebSecurityConfig(
             authorizeHttpRequests {
                 authorize(CorsUtils::isPreFlightRequest, permitAll)
 
-                bundleRequests()
-                claimRequests()
-                tagRequests()
-                questionRequests()
-                memberRequests()
+//                bundleRequests()
+//                claimRequests()
+//                tagRequests()
+//                questionRequests()
+//                memberRequests()
 
                 authorize(anyRequest, permitAll)
             }

--- a/infra/infra-security/src/main/kotlin/com/kw/infrasecurity/config/WebSecurityConfig.kt
+++ b/infra/infra-security/src/main/kotlin/com/kw/infrasecurity/config/WebSecurityConfig.kt
@@ -8,6 +8,8 @@ import com.kw.infrasecurity.oauth.OAuth2UserService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod.*
+import org.springframework.security.config.annotation.web.AuthorizeHttpRequestsDsl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -60,11 +62,62 @@ class WebSecurityConfig(
 
             authorizeHttpRequests {
                 authorize(CorsUtils::isPreFlightRequest, permitAll)
+
+                bundleRequests()
+                claimRequests()
+                tagRequests()
+                questionRequests()
+                memberRequests()
+
                 authorize(anyRequest, permitAll)
             }
         }
 
         return http.build()
+    }
+
+    private fun AuthorizeHttpRequestsDsl.memberRequests() {
+        authorize(GET, "/api/v1/members/me", hasRole("USER"))
+        authorize(PATCH, "/api/v1/members/me/nickname", hasRole("USER"))
+        authorize(PATCH, "/api/v1/members/me/sns", hasRole("USER"))
+        authorize(PATCH, "/api/v1/members/me/tags", hasRole("USER"))
+        authorize(PATCH, "/api/v1/members/me", hasRole("USER"))
+        authorize(PATCH, "/api/v1/members/me/profile-image", hasRole("USER"))
+
+        authorize(GET, "/api/v1/members/{id}", permitAll)
+    }
+
+    private fun AuthorizeHttpRequestsDsl.questionRequests() {
+        authorize(POST, "/api/*/questions", hasRole("USER"))
+        authorize(PATCH, "/api/*/questions/{id}", hasRole("USER"))
+        authorize(DELETE, "/api/*/questions/{id}", hasRole("USER"))
+        authorize(POST, "/api/*/questions/{id}/report", hasRole("USER"))
+
+        authorize(GET, "/api/*/questions/search", permitAll)
+    }
+
+    private fun AuthorizeHttpRequestsDsl.tagRequests() {
+        authorize(GET, "/api/*/tags", permitAll)
+    }
+
+    private fun AuthorizeHttpRequestsDsl.claimRequests() {
+        authorize(POST, "/api/*/claims", hasRole("USER"))
+    }
+
+    private fun AuthorizeHttpRequestsDsl.bundleRequests() {
+        authorize(POST, "/api/*/bundles", hasRole("USER"))
+        authorize(POST, "/api/*/bundles", hasRole("USER"))
+        authorize(PATCH, "/api/*/bundles/bundle-order", hasRole("USER"))
+        authorize(GET, "/api/*/bundles/my", hasRole("USER"))
+        authorize(GET, "/api/*/bundles/{id}", hasRole("USER"))
+        authorize(PATCH, "/api/*/bundles/{id}", hasRole("USER"))
+        authorize(DELETE, "/api/*/bundles/{id}", hasRole("USER"))
+        authorize(POST, "/api/*/bundles/{id}/scrape", hasRole("USER"))
+        authorize(PATCH, "/api/*/bundles/{id}/question-order", hasRole("USER"))
+        authorize(POST, "/api/*/bundles/questions", hasRole("USER"))
+        authorize(DELETE, "/api/*/bundles/{id}/questions", hasRole("USER"))
+
+        authorize(GET, "/api/*/bundles/search", permitAll)
     }
 
     @Bean

--- a/infra/infra-security/src/main/kotlin/com/kw/infrasecurity/jwt/JwtAccessDeniedHandler.kt
+++ b/infra/infra-security/src/main/kotlin/com/kw/infrasecurity/jwt/JwtAccessDeniedHandler.kt
@@ -9,13 +9,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerExceptionResolver
 
 @Component
-class JwtAccessDeniedHandler() : AccessDeniedHandler {
-
-    private lateinit var resolver: HandlerExceptionResolver
-
-    constructor (@Qualifier("handlerExceptionResolver") resolver: HandlerExceptionResolver) : this() {
-        this.resolver = resolver
-    }
+class JwtAccessDeniedHandler(@Qualifier("handlerExceptionResolver") val resolver: HandlerExceptionResolver) : AccessDeniedHandler {
 
     override fun handle(
         request: HttpServletRequest?,

--- a/infra/infra-security/src/main/kotlin/com/kw/infrasecurity/jwt/JwtAuthenticationEntryPoint.kt
+++ b/infra/infra-security/src/main/kotlin/com/kw/infrasecurity/jwt/JwtAuthenticationEntryPoint.kt
@@ -9,13 +9,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerExceptionResolver
 
 @Component
-class JwtAuthenticationEntryPoint() : AuthenticationEntryPoint {
-
-    private lateinit var resolver: HandlerExceptionResolver
-
-    constructor (@Qualifier("handlerExceptionResolver") resolver: HandlerExceptionResolver) : this() {
-        this.resolver = resolver
-    }
+class JwtAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") val resolver: HandlerExceptionResolver) : AuthenticationEntryPoint {
 
     override fun commence(
         request: HttpServletRequest?,

--- a/infra/infra-security/src/main/kotlin/com/kw/infrasecurity/jwt/JwtAuthenticationFilter.kt
+++ b/infra/infra-security/src/main/kotlin/com/kw/infrasecurity/jwt/JwtAuthenticationFilter.kt
@@ -26,9 +26,9 @@ class JwtAuthenticationFilter(private val tokenProvider: JwtTokenProvider) : Onc
                 } catch (e: Exception) {
                     request.setAttribute("exception", e)
                 }
+            } else {
+                request.setAttribute("exception", AccessDeniedException("요청이 거부되었습니다"))
             }
-        } else {
-            request.setAttribute("exception", AccessDeniedException("요청이 거부되었습니다"))
         }
         filterChain.doFilter(request, response)
     }

--- a/server/api/src/main/kotlin/com/kw/api/common/exception/ApiExceptionHandler.kt
+++ b/server/api/src/main/kotlin/com/kw/api/common/exception/ApiExceptionHandler.kt
@@ -17,9 +17,8 @@ import java.security.SignatureException
 
 private val logger = KotlinLogging.logger {}
 
-@RestControllerAdvice
+@RestControllerAdvice("com.kw")
 class ApiExceptionHandler : ResponseEntityExceptionHandler() {
-
 
     override fun handleHttpMessageNotReadable(
         ex: HttpMessageNotReadableException,

--- a/server/api/src/main/kotlin/com/kw/api/domain/member/controller/MemberController.kt
+++ b/server/api/src/main/kotlin/com/kw/api/domain/member/controller/MemberController.kt
@@ -79,4 +79,9 @@ class MemberController(private val memberService: MemberService) {
         return response
     }
 
+    @Operation(summary = "회원 닉네임 중복검사를 합니다.")
+    @GetMapping("/nickname/validate-duplicate")
+    fun isMemberNicknameDuplicate(@RequestParam nickname: String) {
+        memberService.isMemberNicknameDuplicate(nickname)
+    }
 }

--- a/server/api/src/main/kotlin/com/kw/api/domain/member/service/MemberService.kt
+++ b/server/api/src/main/kotlin/com/kw/api/domain/member/service/MemberService.kt
@@ -72,6 +72,12 @@ class MemberService(
         return MemberInfoResponse.from(member)
     }
 
+    fun isMemberNicknameDuplicate(
+        nickname: String
+    ) {
+        isNicknameUnique(nickname);
+    }
+
     private fun updateMemberInfoSns(
         member: Member,
         snsRequests: List<MemberSnsUpdateRequest.SnsRequest>


### PR DESCRIPTION
## 구현 기능
- 닉네임 중복 체크 api 추가
- api path 권한 설정 추가 (익셉션 처리 이상으로 일단 주석처리)

resolve: #59 
