### PR TITLE
fix: 특정 키워드 검색 안되는 버그 수정, member 마이그레이션 파일 작성

### DIFF
--- a/data/src/main/kotlin/com/kw/data/common/util/CustomFunction.kt
+++ b/data/src/main/kotlin/com/kw/data/common/util/CustomFunction.kt
@@ -14,7 +14,7 @@ class CustomFunction {
                 java.lang.Double::class.java,
                 "FUNCTION('MATCH_AGAINST', {0}, {1})",
                 target,
-                "$keyword*"
+                keyword.trim().split(" ").joinToString(" ") { "+$it" }
             ).gt(0)
         }
     }

--- a/data/src/main/resources/db/migration/V2__alter_member.sql
+++ b/data/src/main/resources/db/migration/V2__alter_member.sql
@@ -1,0 +1,19 @@
+-- delete_at 컬럼 삭제
+ALTER TABLE member
+    DROP COLUMN deleted_at;
+
+-- delted_at과 묶여있던 nickname, email 멀티 유니크 인덱스 삭제
+ALTER TABLE member
+    DROP INDEX member_unique_idx_nickname_and_deleted_at;
+ALTER TABLE member
+    DROP INDEX member_unique_idx_email_and_deleted_at;
+
+-- nickname 컬럼 타입 변경
+ALTER TABLE member
+    MODIFY nickname VARCHAR (50) NULL;
+
+-- nickname, email 컬럼에 유니크 인덱스 추가
+ALTER TABLE member
+    ADD UNIQUE INDEX member_unique_idx_nickname (nickname);
+ALTER TABLE member
+    ADD UNIQUE INDEX member_unique_idx_email (email);

--- a/server/api/src/main/kotlin/com/kw/api/domain/bundle/dto/request/BundleCreateRequest.kt
+++ b/server/api/src/main/kotlin/com/kw/api/domain/bundle/dto/request/BundleCreateRequest.kt
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.Size
 data class BundleCreateRequest(
 
     @field:NotBlank(message = "이름은 필수입니다.")
-    @field:Size(max = 100, message = "이름은 최대 5자까지 입력해 주세요.")
+    @field:Size(min = 2, max = 100, message = "이름은 최소 2자, 최대 100자까지 입력해 주세요.")
     val name: String,
 
     val shareType: Bundle.ShareType,

--- a/server/api/src/main/kotlin/com/kw/api/domain/question/dto/request/QuestionCreateRequest.kt
+++ b/server/api/src/main/kotlin/com/kw/api/domain/question/dto/request/QuestionCreateRequest.kt
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.Size
 data class QuestionCreateRequest(
 
     @field:NotBlank(message = "내용은 필수입니다.")
-    @field:Size(max = 300, message = "내용은 최대 300자까지 입력해 주세요.")
+    @field:Size(min = 2, max = 300, message = "내용은 최소 2자, 최대 300자까지 입력해 주세요.")
     val content: String,
 
     @field:Size(max = 1500, message = "답변은 최대 1500자까지 입력해 주세요.")


### PR DESCRIPTION
## 구현 기능
- 검색 정확도를 높이기 위해 검색 쿼리 시 각 단어에 boolean 연산자(+) 붙이도록 수정했습니다.
- 특정 단어가 검색이 안되던 이슈는 아래 파라미터 값들을 재조정 후 인덱스를 다시 생성하여 해결하였습니다.
  -  ngram_token_size=1
  -  ft_min_word_len=1
  -  innodb_ft_min_token_size=1
  -  innodb_ft_enable_stopword=0
- 꾸러미 제목, 질문 내용 최소 글자수 제한 추가 
- 테스트용 유저 테이블 마이그레이션 파일 생성했습니다. 또 dev 환경에서는 동작 안하도록 환경변수도 수정했습니다.

resolve: #89 
resolve: #97 
